### PR TITLE
fix panic when mystat.Hoststatus[host] is nil

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func (raw *rawstatus) blockToStruct(mystat *Mainstat, wg *sync.WaitGroup) {
 		err = json.Unmarshal(a, &tempstat)
 		checkErr(err)
 		mystat.Hoststatus[host] = &tempstat
-	} else if ident == "servicestatus" {
+	} else if ident == "servicestatus" && mystat.Hoststatus[host] != nil {
 		if len(mystat.Hoststatus[host].Servicestatus) == 0 {
 			mystat.Hoststatus[host].Servicestatus = make(map[string]*Servicestatus)
 		}


### PR DESCRIPTION
In case `mystat.Hoststatus[host]` is nil, panic occured.
(My status.dat has some nil entries)

This PR fix this problem.
